### PR TITLE
Address PTS/DTS section by mapping 'are' to 'shall'.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -472,7 +472,7 @@ The highest level that may occur in an AV1 video stream, as well as a profile an
 
 For AV1 video stream multiplexed into [[!MPEG-2-TS]], the *decoder_model_info* may not be present. If the *decoder_model_info* is present, then the STD model shall match with the decoder model defined in Annex E of [[!AV1]].
 
-For synchronization and STD management, PTSs and, when appropriate, DTSs are encoded in the header of the PES packet that carries the AV1 video stream data setting the PTS_DTS_flags to '01' or '11'. For PTS and DTS encoding, the constraints and semantics apply as defined in the PES Header and associated constraints on timestamp intervals.
+For synchronization and STD management, PTSs and, when appropriate, DTSs shall be encoded in the header of the PES packet that carries the AV1 video stream data setting the PTS_DTS_flags to '01' or '11'. For PTS and DTS encoding, the constraints and semantics apply as defined in the PES Header and associated constraints on timestamp intervals.
 
 There are cases in AV1 bitstreams where information about a frame is sent multiple times. For example, first to be decoded, and subsequently to be displayed. In the case of a frame being decoded but not displayed, it is desired to assign a valid DTS but without need for a PTS. However, the MPEG2-TS specification prevents a DTS from being transmitted without a PTS. Hence, a PTS is always assigned for AV1 access units and its value is not relevant for frames being decoded but not displayed.
 


### PR DESCRIPTION
4.1.6.10 PTS/DTS -> map to 3.5.

Text in 4.1.6.10 should already be covered:
"For AV1 Bitstreams:
Encoding:      	Every PES header shall contain the Presentation Time Stamp and the Decoding Time Stamp (only if it differs from the Presentation Time Stamp).
Decoding:      	If Presentation Time Stamp is available and Decoding Time Stamp is not available for the access unit in the PES packet, the AV1 IRD shall set the Decoding Time Stamp equal to the Presentation Time Stamp (per Recommendation ITU‑T H.222.0 / ISO/IEC 13818-1 [Error! Reference source not found.])."