### PR TITLE
Addresses editorial feedback from Yannis, Maryla, and Thomas

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -235,7 +235,7 @@ AV1_video_descriptor() {
 </tr>
 </tbody></table>
 
-<b><code>reserved_zeros</code></b> - Will be set to zeroes.
+<b><code>reserved_zeros</code></b> - Shall be set to zeroes.
 
 <b><code>initial_presentation_delay_present</code></b> - Indicates <b><code>initial_presentation_delay_minus_one</code></b> field is present.
 

--- a/index.bs
+++ b/index.bs
@@ -26,28 +26,28 @@ Max ToC Depth: 3
     "publisher": "ISO"
   },
   "BT-1886": {
-    "title": "Recommendation ITU-R BT.1886-0 (2011), Reference electro-optical transfer function for flat panel displays used in HDTV studio production",
+    "title": "Recommendation ITU-R BT.1886-0, Reference electro-optical transfer function for flat panel displays used in HDTV studio production",
     "href": "https://www.itu.int/rec/R-REC-BT.1886",
     "status": "Recommendation",
     "publisher": "ITU",
     "date": "2011"
   },
   "BT-709": {
-    "title": "Recommendation ITU-R BT.709-6 (2015), Parameter values for the HDTV standards for production and international programme exchange",
+    "title": "Recommendation ITU-R BT.709-6, Parameter values for the HDTV standards for production and international programme exchange",
     "href": "https://www.itu.int/rec/R-REC-BT.709",
     "status": "Recommendation",
     "publisher": "ITU",
     "date": "2015"
   },
   "BT-2100": {
-    "title": "Recommendation ITU-R BT.2100-2 (2018), Image parameter values for high dynamic range television for use in production and international programme exchange",
+    "title": "Recommendation ITU-R BT.2100-2, Image parameter values for high dynamic range television for use in production and international programme exchange",
     "href": "https://www.itu.int/rec/R-REC-BT.2100",
     "status": "Recommendation",
     "publisher": "ITU",
     "date": "2018"
   },
   "BT-2020": {
-    "title": "Recommendation ITU-R BT.2020-2 (2015), Parameter values for ultra-high definition television systems for production and international programme exchange",
+    "title": "Recommendation ITU-R BT.2020-2, Parameter values for ultra-high definition television systems for production and international programme exchange",
     "href": "https://www.itu.int/rec/R-REC-BT.2020",
     "status": "Recommendation",
     "publisher": "ITU",

--- a/index.bs
+++ b/index.bs
@@ -26,22 +26,32 @@ Max ToC Depth: 3
     "publisher": "ISO"
   },
   "BT-1886": {
-    "title": "Recommendation BT.1886 : Reference electro-optical transfer function for flat panel displays used in HDTV studio production",
+    "title": "Recommendation ITU-R BT.1886-0 (2011), Reference electro-optical transfer function for flat panel displays used in HDTV studio production",
     "href": "https://www.itu.int/rec/R-REC-BT.1886",
     "status": "Recommendation",
-    "publisher": "ITU"
+    "publisher": "ITU",
+    "date": "2011"
   },
   "BT-709": {
-    "title": "Recommendation BT.709 : Parameter values for the HDTV standards for production and international programme exchange",
+    "title": "Recommendation ITU-R BT.709-6 (2015), Parameter values for the HDTV standards for production and international programme exchange",
     "href": "https://www.itu.int/rec/R-REC-BT.709",
     "status": "Recommendation",
-    "publisher": "ITU"
+    "publisher": "ITU",
+    "date": "2015"
+  },
+  "BT-2100": {
+    "title": "Recommendation ITU-R BT.2100-2 (2018), Image parameter values for high dynamic range television for use in production and international programme exchange",
+    "href": "https://www.itu.int/rec/R-REC-BT.2100",
+    "status": "Recommendation",
+    "publisher": "ITU",
+    "date": "2018"
   },
   "BT-2020": {
-    "title": "Recommendation BT.2020 : Parameter values for ultra-high definition television systems for production and international programme exchange",
+    "title": "Recommendation ITU-R BT.2020-2 (2015), Parameter values for ultra-high definition television systems for production and international programme exchange",
     "href": "https://www.itu.int/rec/R-REC-BT.2020",
     "status": "Recommendation",
-    "publisher": "ITU"
+    "publisher": "ITU",
+    "date": "2015"
   }
 }
 </pre>
@@ -208,7 +218,7 @@ AV1_video_descriptor() {
 
 <b><code>seq_tier_0</code></b>, <b><code>twelve_bit</code></b>, <b><code>monochrome</code></b>, <b><code>chroma_subsampling_x</code></b>, <b><code>chroma_subsampling_y</code></b>, <b><code>chroma_sample_position</code></b> - These fields shall be coded according to the same semantics when they are present. If they are not present, they will be coded using the value inferred by the semantics.
 
-<b><code>hdr_wcg_idc</code></b> - The value of this syntax element indicates the presence or absence of high dynamic range (HDR) and/or wide color gamut (WCG) video components in the associated PID according to the table below. HDR is defined to be video that has high dynamic range if the video stream EOTF is higher than the reference EOTF defined in [[!BT-1886]]. WCG is defined to be video that is coded using colour primaries with a colour gamut not contained within [[!BT-709]].
+<b><code>hdr_wcg_idc</code></b> - The value of this syntax element indicates the presence or absence of high dynamic range (HDR) and/or wide color gamut (WCG) video components in the associated PID according to the table below. HDR is defined to be video that uses an HDR transfer function, such as those defined in [[!BT-2100]] (PQ or HLG). WCG is defined to be video that is coded using colour primaries with a colour gamut not contained within [[!BT-709]].
 
 <table class="spec-table">
 <thead>
@@ -227,7 +237,7 @@ AV1_video_descriptor() {
 </tr>
 <tr>
 <td align="center">2</td>
-<td align="left">Both HDR and WCG are to be indicated in the stream</td>
+<td align="left">The video stream is both HDR and WCG</td>
 </tr>
 <tr>
 <td align="center">3</td>

--- a/index.bs
+++ b/index.bs
@@ -276,7 +276,7 @@ Prior to carriage into PES, the AV1 <b><code>open_bitstream_unit()</code></b> is
 
 ```cpp
 ts_open_bitstream_unit(NumBytesInTsObu) {
-    uimsbf(24) obu_start_code;   /* equal to 0x01 */
+    uimsbf(24) obu_start_code;   /* equal to 0x000001 */
     NumBytesInObu = 0
     for( i = 2; i < NumBytesInTsObu; i++ ) {
         if( i + 2 < NumBytesInTsObu && nextbits(24) == 0x000003 ) {


### PR DESCRIPTION
### Done
   - **reserved_zeros**: Changed "Will be set to zeroes" to "Shall be set to zeroes"
   - **obu_start_code comment**: Fixed `0x01` to `0x000001` to match the 24-bit field width
   - **hdr_wcg_idc table (value 2)**: Replaced confusing "Both HDR and WCG are to be indicated in the stream" with "The video stream is both HDR and WCG"
   - **HDR definition**: Replaced vague "EOTF higher than BT-1886" with reference to BT-2100 HDR transfer functions (PQ or HLG)
   - **Bibliography**: Added BT-2100 entry and updated all BT references to use formal ITU-R citation format with version and date

   ### Still to be discussed / done
   - **Simplify hdr_wcg_idc table entries 0 and 1**: Remove "container" language per Maryla's suggestion (e.g. 0 = "A video that is neither HDR nor WCG, i.e. an SDR video", 1 = "A video that is WCG but not HDR")
   - **format_identifier hex notation**: Optionally add hex value (0x41563031) alongside the ASCII 'AV01'. Further thoughts on this?
   - **obu_size recommendation text**: Currently says "easy conversion to MP4" but applies to MP4 and Annex B, wording could be broadened
